### PR TITLE
Attempt to implement update bid, return unsuccessful bids and refund

### DIFF
--- a/contracts/Event.sol
+++ b/contracts/Event.sol
@@ -134,6 +134,10 @@ contract Event {
         events[eventId].firstTicketId = ticketId;
     }
 
+    function setEventTicketsLeft(uint256 eventId, uint256 ticketsLeft) public validEventId(eventId) {
+        events[eventId].ticketsLeft = ticketsLeft;
+    }
+
     function getLatestEventId() public view returns (uint256) {
         return numEvents - 1;
     }

--- a/contracts/Platform.sol
+++ b/contracts/Platform.sol
@@ -180,9 +180,11 @@ contract Platform {
             if (bidAmount == 0) break;
             bidAmount--;
         }
+        
+        // Update event tickets left
+        eventContract.setEventTicketsLeft(eventId, ticketsLeft);
 
-        // TODO: Return unsuccessful bidders
-        // returnBiddings()
+        // Change state to allow normal buying
         eventContract.setEventBidState(eventId, Event.bidState.buy);
         emit BidBuy(eventId);
     }   

--- a/contracts/Platform.sol
+++ b/contracts/Platform.sol
@@ -161,17 +161,21 @@ contract Platform {
         uint256 ticketId = eventContract.getEventFirstTicketId(eventId);
 
         // Tickets given out starting from top bidders
-        while (ticketsLeft != 0) {
+        while (true) {
             address[] memory bidderList = eventBiddings[eventId][bidAmount];
             for (uint256 i = 0; i < bidderList.length; i++) {
                 if (bidderList[i] == address(0)) continue; 
 
-                ticketContract.transferTicket(ticketId, bidderList[i]); 
-                ticketId++;
-                ticketsLeft--;
-
-                //burnToken()
-                if (ticketsLeft == 0) break;
+                if (ticketsLeft != 0) {
+                    ticketContract.transferTicket(ticketId, bidderList[i]); 
+                    ticketId++;
+                    ticketsLeft--;
+                    //burnToken()
+                } else { 
+                    // return ETH back to unsuccessful bidders when ticketsLeft == 0 
+                    address payable recipient = address(uint168(bidderList[i]));
+                    recipient.transfer(eventContract.getEventTicketPrice(eventId));
+                }
             }
             if (bidAmount == 0) break;
             bidAmount--;

--- a/contracts/Platform.sol
+++ b/contracts/Platform.sol
@@ -117,6 +117,7 @@ contract Platform {
     // Update bid
     function updateBid(uint256 eventId, uint256 tokenBid) public isBuyer() {
         bidInfo memory currentBidInfo = addressBiddings[msg.sender][eventId];
+        require(currentBidInfo.quantity != 0, "Cant update bid without placing bid first");
         require(tokenBid > currentBidInfo.tokenPerTicket, "New token bid must be higher than current bid");
 
         uint256 tokenDifference = tokenBid - currentBidInfo.tokenPerTicket;

--- a/contracts/Platform.sol
+++ b/contracts/Platform.sol
@@ -189,11 +189,6 @@ contract Platform {
         emit BidBuy(eventId);
     }   
 
-    // Return unsuccessful bidders their corresponding ETH and tokens
-    function returnBiddings() public {
-
-    }
-
     /* Viewing the number of tickets left for an event */
     function viewTicketsLeft(uint256 eventId) public view returns (uint256) {
         return eventContract.getEventTicketsLeft(eventId);

--- a/test/test_platform.js
+++ b/test/test_platform.js
@@ -195,4 +195,54 @@ contract("Platform", function (accounts) {
         assert.strictEqual(owner5, accounts[3]);
     });
 
+    it("Test Updating of Bid", async () => {
+        // Listing of event with 1 tickets
+        await platformInstance.listEvent("Title 1", "Venue 1", 2024, 3, 11, 12, 30, 0, 1, 1, 20, accounts[1], {from: accounts[1], value: oneEth.multipliedBy(4)});
+        let latestEventId = (await eventInstance.getLatestEventId()).toNumber();
+        const title = await eventInstance.getEventTitle(latestEventId);
+        await assert("Title 1", title, "Failed to create event");
+
+        // Commence bidding
+        let bidCommenced = await platformInstance.commenceBidding(latestEventId, {from: accounts[1]});
+        truffleAssert.eventEmitted(bidCommenced, "BidCommenced");
+        
+        // Generate token for accounts[2],[3] with 5,6 correspondingly
+        await eventTokenInstance.getTokenForTesting(accounts[2], 5, {from: accounts[0]});
+        await eventTokenInstance.getTokenForTesting(accounts[3], 6, {from: accounts[0]});
+        const acc2token = new BigNumber(await eventTokenInstance.checkEventToken({from: accounts[2]}));
+        await assert(acc2token.isEqualTo(BigNumber(5)), "EventToken not minted");
+        const acc3token = new BigNumber(await eventTokenInstance.checkEventToken({from: accounts[3]}));
+        await assert(acc3token.isEqualTo(BigNumber(6)), "EventToken not minted");
+
+        // accounts[3] place bid for 1 ticket with 0 tokens each
+        let bidPlaced1 = await platformInstance.placeBid(latestEventId, 1, 0, {from: accounts[3], value: oneEth});
+        truffleAssert.eventEmitted(bidPlaced1, "BidPlaced");
+
+        // accounts[2] approve Platform contract to use 5 tokens and place bid for 1 ticket with 5 tokens each
+        await eventTokenInstance.approveToken(platformInstance.address, 5, {from: accounts[2]}); 
+        let acc2allowance = new BigNumber(await eventTokenInstance.checkAllowance(accounts[2], platformInstance.address, {from: accounts[2]}));
+        await assert(acc2allowance.isEqualTo(BigNumber(5)), "EventToken not approved");
+        let bidPlaced2 = await platformInstance.placeBid(latestEventId, 1, 5, {from: accounts[2], value: oneEth});
+        truffleAssert.eventEmitted(bidPlaced2, "BidPlaced");
+
+        // accounts[3] approve Platform contract to use 6 tokens and update bid for 1 ticket with 6 tokens each
+        await eventTokenInstance.approveToken(platformInstance.address, 6, {from: accounts[3]}); 
+        let acc3allowance = new BigNumber(await eventTokenInstance.checkAllowance(accounts[3], platformInstance.address, {from: accounts[3]}));
+        await assert(acc3allowance.isEqualTo(BigNumber(6)), "EventToken not approved");
+        let updateBid1 = await platformInstance.updateBid(latestEventId, 6, {from: accounts[3]});
+        truffleAssert.eventEmitted(updateBid1, "BidUpdate");
+
+        // Ensure that platform EventToken amount is consistent
+        const acc0token = new BigNumber(await eventTokenInstance.checkEventTokenOf(Platform.address, {from: accounts[0]}));
+        await assert(acc0token.isEqualTo(BigNumber(22)), "EventToken not transfered to Platform");
+   
+        // Close bid
+        let bidClosed = await platformInstance.closeBidding(latestEventId, {from: accounts[1]});
+        truffleAssert.eventEmitted(bidClosed, "BidBuy");
+
+        // Ensure accurate ticket distribution
+        let owner1 = await ticketInstance.getTicketOwner(15); // ticketId 15 belongs to accounts[3]
+        assert.strictEqual(owner1, accounts[3]);
+    });
+
 })

--- a/test/test_platform.js
+++ b/test/test_platform.js
@@ -196,7 +196,7 @@ contract("Platform", function (accounts) {
     });
 
     it("Test Updating of Bid", async () => {
-        // Listing of event with 1 tickets
+        // Listing of event with 1 ticket
         await platformInstance.listEvent("Title 1", "Venue 1", 2024, 3, 11, 12, 30, 0, 1, 1, 20, accounts[1], {from: accounts[1], value: oneEth.multipliedBy(4)});
         let latestEventId = (await eventInstance.getLatestEventId()).toNumber();
         const title = await eventInstance.getEventTitle(latestEventId);
@@ -246,7 +246,7 @@ contract("Platform", function (accounts) {
     });
 
     it("Test Unsuccessful Bid Return ETH", async () => {
-        // Listing of event with 1 tickets
+        // Listing of event with 1 ticket
         await platformInstance.listEvent("Title 1", "Venue 1", 2024, 3, 11, 12, 30, 0, 1, 1, 20, accounts[1], {from: accounts[1], value: oneEth.multipliedBy(4)});
         let latestEventId = (await eventInstance.getLatestEventId()).toNumber();
         const title = await eventInstance.getEventTitle(latestEventId);
@@ -274,8 +274,6 @@ contract("Platform", function (accounts) {
 
         // Ensure ETH is returned to unsuccessful bidder accounts[3]
         let finalbalance = new BigNumber(await web3.eth.getBalance(accounts[3]));
-        // console.log(balance1);
-        // console.log(balance2);
         await assert(finalbalance.isEqualTo(initialbalance.minus(gasPrice.multipliedBy(gasUsed))), "Did not return ETH back to unsuccessful bidders");
 
     });


### PR DESCRIPTION
Using original data structure, I implemented the following along with testcases
1. Update bid
2. Return unsuccessful bidders
3. Refund after bidding closes and test ticket still can be bought after refund

![image](https://user-images.githubusercontent.com/28041798/229274914-7b4350d4-8dbd-4c4e-9321-52cd30506378.png)
